### PR TITLE
Add main menu, multi-level progression, and leaderboard

### DIFF
--- a/game.js
+++ b/game.js
@@ -8,20 +8,170 @@
   const ticketTotalEl = document.getElementById("ticket-total");
   const statusEl = document.getElementById("status");
   const restartButton = document.getElementById("restart-button");
+  const mainMenu = document.getElementById("main-menu");
+  const playButton = document.getElementById("play-button");
+  const characterButton = document.getElementById("character-button");
+  const levelButton = document.getElementById("level-button");
+  const characterPanel = document.getElementById("character-panel");
+  const characterOptionsEl = document.getElementById("character-options");
+  const levelPanel = document.getElementById("level-panel");
+  const levelListEl = document.getElementById("level-list");
+  const leaderboardListEl = document.getElementById("leaderboard-list");
+  const leaderboardEmptyEl = document.getElementById("leaderboard-empty");
+  const lastRunSummaryEl = document.getElementById("last-run-summary");
+  const lastRunListEl = document.getElementById("last-run-list");
+  const levelTimerEl = document.getElementById("level-timer");
+  const totalTimerEl = document.getElementById("total-timer");
+  const currentLevelNameEl = document.getElementById("current-level-name");
+  const hudEl = document.querySelector(".hud");
+  const gameAreaEl = document.querySelector(".game-area");
 
   const keys = {
     left: false,
     right: false,
   };
 
-  const confettiPieces = [];
-  const collectibles = [];
-  let platforms = [];
-  let dog;
+  const STORAGE_KEY = "sambaVoltigeurProgress";
 
-  const gravity = 0.65;
-  const terminalVelocity = 17;
+  const GAME_STATES = {
+    MENU: "menu",
+    PLAYING: "playing",
+    CELEBRATING: "celebrating",
+  };
 
+  const skins = [
+    {
+      id: "samba",
+      name: "Samba",
+      body: "#c67c48",
+      spots: "#d89a64",
+      outline: "#6f3a1b",
+    },
+    {
+      id: "neige",
+      name: "Neige",
+      body: "#f2f2f2",
+      spots: "#dcdcdc",
+      outline: "#7f7f7f",
+    },
+    {
+      id: "cacao",
+      name: "Cacao",
+      body: "#5c3115",
+      spots: "#7a4520",
+      outline: "#2f1708",
+    },
+    {
+      id: "soleil",
+      name: "Soleil",
+      body: "#f7c873",
+      spots: "#f2a65c",
+      outline: "#9c6428",
+    },
+  ];
+
+  const levels = [
+    {
+      id: "carnaval",
+      index: 0,
+      name: "Carnaval",
+      theme: "carnaval",
+      intro: "Collecte tous les tickets pour déclencher la fête.",
+      spawn: { x: 80, y: 360 },
+      createPlatforms: () => [
+        { x: 0, y: 470, width: canvas.width, height: 70, color: "#ffcf4a", accent: "#ffe9a3", label: "Scène Samba" },
+        { x: 110, y: 360, width: 170, height: 26, color: "#ff5ea3", accent: "#ffd2ec", label: "Char Tambours" },
+        { x: 330, y: 305, width: 150, height: 26, color: "#2ddf7c", accent: "#b8ffde", label: "Stand Limonade" },
+        { x: 530, y: 245, width: 190, height: 28, color: "#6a00f4", accent: "#d9c7ff", label: "Char Confettis" },
+        { x: 770, y: 340, width: 140, height: 26, color: "#ff7f50", accent: "#ffd1c2", label: "Float Bonbons" },
+        { x: 660, y: 430, width: 120, height: 22, color: "#00c2ff", accent: "#c6f3ff", label: "Chariot Glaces" },
+        { x: 420, y: 410, width: 120, height: 22, color: "#ffd447", accent: "#fff2a6", label: "Tambours" },
+      ],
+      tickets: [
+        { x: 180, y: 320, phase: 0.1 },
+        { x: 375, y: 265, phase: 0.5 },
+        { x: 600, y: 205, phase: 0.9 },
+        { x: 810, y: 300, phase: 1.4 },
+        { x: 700, y: 390, phase: 1.9 },
+        { x: 480, y: 370, phase: 2.2 },
+        { x: 260, y: 350, phase: 2.8 },
+      ],
+    },
+    {
+      id: "pirate",
+      index: 1,
+      name: "Bateau pirate",
+      theme: "pirate",
+      intro: "Récupère les billets avant que le capitaine ne revienne !",
+      spawn: { x: 90, y: 360 },
+      createPlatforms: () => [
+        { x: 0, y: 470, width: canvas.width, height: 70, color: "#13334c", accent: "#0f4c75", label: "Océan" },
+        { x: 120, y: 340, width: 200, height: 28, color: "#8c5a2b", accent: "#c7894f", label: "Pont principal" },
+        { x: 360, y: 280, width: 180, height: 26, color: "#8c5a2b", accent: "#c7894f", label: "Mât central" },
+        { x: 620, y: 320, width: 190, height: 26, color: "#8c5a2b", accent: "#c7894f", label: "Quartier des canons" },
+        { x: 780, y: 260, width: 150, height: 24, color: "#8c5a2b", accent: "#c7894f", label: "Barre du capitaine" },
+        { x: 500, y: 400, width: 150, height: 24, color: "#8c5a2b", accent: "#c7894f", label: "Pont inférieur" },
+        { x: 300, y: 420, width: 130, height: 24, color: "#8c5a2b", accent: "#c7894f", label: "Quartier arrière" },
+      ],
+      tickets: [
+        { x: 160, y: 300, phase: 0.3 },
+        { x: 420, y: 240, phase: 0.6 },
+        { x: 690, y: 270, phase: 0.9 },
+        { x: 840, y: 220, phase: 1.3 },
+        { x: 560, y: 360, phase: 1.8 },
+        { x: 360, y: 380, phase: 2.1 },
+        { x: 220, y: 330, phase: 2.4 },
+      ],
+    },
+    {
+      id: "jouets",
+      index: 2,
+      name: "Magasin de jouets",
+      theme: "jouets",
+      intro: "Bondis de rayon en rayon pour attraper chaque ticket surprise !",
+      spawn: { x: 90, y: 360 },
+      createPlatforms: () => [
+        { x: 0, y: 470, width: canvas.width, height: 70, color: "#f4a261", accent: "#ffd5a1", label: "Allée principale" },
+        { x: 120, y: 360, width: 150, height: 24, color: "#ff85a1", accent: "#ffc1d8", label: "Rayon peluches" },
+        { x: 320, y: 310, width: 140, height: 24, color: "#66d0ff", accent: "#b9ecff", label: "Briques géantes" },
+        { x: 520, y: 250, width: 180, height: 26, color: "#2ddf7c", accent: "#9ef7c1", label: "Circuit voitures" },
+        { x: 740, y: 200, width: 160, height: 24, color: "#ffe066", accent: "#fff2a6", label: "Château jouet" },
+        { x: 640, y: 360, width: 160, height: 24, color: "#d38eff", accent: "#f0d5ff", label: "Rayon robots" },
+        { x: 420, y: 420, width: 160, height: 24, color: "#ffb347", accent: "#ffd9a3", label: "Trampoline pop" },
+      ],
+      tickets: [
+        { x: 160, y: 320, phase: 0.3 },
+        { x: 360, y: 270, phase: 0.7 },
+        { x: 540, y: 220, phase: 1.1 },
+        { x: 760, y: 170, phase: 1.5 },
+        { x: 680, y: 320, phase: 1.9 },
+        { x: 460, y: 380, phase: 2.3 },
+        { x: 260, y: 350, phase: 2.6 },
+      ],
+    },
+  ];
+
+  const defaultProgress = {
+    unlockedLevels: 1,
+    bestLevelTimes: {},
+    leaderboard: [],
+    selectedSkinId: skins[0].id,
+  };
+
+  let progress = loadProgress();
+  progress = {
+    ...defaultProgress,
+    ...progress,
+    unlockedLevels: Math.max(1, Math.min(levels.length, progress?.unlockedLevels ?? 1)),
+  };
+
+  let currentSkin = skins.find((skin) => skin.id === progress.selectedSkinId) ?? skins[0];
+  let selectedLevelIndex = Math.min(progress.unlockedLevels - 1, levels.length - 1);
+  let currentLevelIndex = selectedLevelIndex;
+  let currentLevel = levels[currentLevelIndex];
+  let gameState = GAME_STATES.MENU;
+
+  let levelTimer = 0;
   let score = 0;
   let celebration = false;
   let celebrationTimer = 0;
@@ -31,17 +181,81 @@
   let jumpBuffer = 0;
   let coyoteTimer = 0;
 
+  let currentRun = createEmptyRun(selectedLevelIndex);
+  let lastRunResults = null;
+  let pendingMenuTimeout = null;
+
+  const skinButtons = new Map();
+  const levelButtonRefs = [];
+
+  const confettiPieces = [];
+  const collectibles = [];
+  let platforms = [];
+  let dog;
+
+  const gravity = 0.65;
+  const terminalVelocity = 17;
+
   const confettiColors = ["#ffe066", "#ff5ea3", "#2ddf7c", "#66d0ff", "#ffffff"];
 
   restartButton.addEventListener("click", () => {
-    resetGame();
+    restartCurrentLevel();
     restartButton.blur();
   });
 
+  playButton.addEventListener("click", handlePlayClick);
+  characterButton.addEventListener("click", () => togglePanel(characterButton, characterPanel));
+  levelButton.addEventListener("click", () => togglePanel(levelButton, levelPanel));
+
+  const gameplayKeyCodes = [
+    "ArrowLeft",
+    "ArrowRight",
+    "ArrowUp",
+    "Space",
+    "KeyA",
+    "KeyD",
+    "KeyQ",
+    "KeyW",
+    "KeyZ",
+  ];
+
+  function isMenuControl(target) {
+    if (!target || target === canvas || target === document.body || target === document.documentElement) {
+      return false;
+    }
+
+    if (target instanceof Element) {
+      if (target instanceof HTMLElement && target.isContentEditable) {
+        return true;
+      }
+
+      const interactive = target.closest(
+        "button, [role='button'], [role='menuitem'], a[href], input, select, textarea, summary, [tabindex]:not([tabindex='-1'])"
+      );
+
+      if (interactive && interactive !== canvas) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   window.addEventListener("keydown", (event) => {
     const code = event.code;
-    if (["ArrowLeft", "ArrowRight", "ArrowUp", "Space", "KeyA", "KeyD", "KeyQ", "KeyW", "KeyZ"].includes(code)) {
-      event.preventDefault();
+    const isGameplayKey = gameplayKeyCodes.includes(code);
+
+    if (isGameplayKey && gameState === GAME_STATES.PLAYING) {
+      if (!isMenuControl(event.target) && !isMenuControl(document.activeElement)) {
+        event.preventDefault();
+      }
+    }
+
+    if (gameState !== GAME_STATES.PLAYING) {
+      if (code === "Escape") {
+        closePanels();
+      }
+      return;
     }
 
     switch (code) {
@@ -66,6 +280,10 @@
   });
 
   window.addEventListener("keyup", (event) => {
+    if (gameState !== GAME_STATES.PLAYING) {
+      return;
+    }
+
     switch (event.code) {
       case "ArrowLeft":
       case "KeyA":
@@ -81,10 +299,49 @@
     }
   });
 
-  function resetGame() {
+  function startLevel(levelIndex, { continueRun = false } = {}) {
+    clearPendingMenuTimeout();
+
+    const level = levels[levelIndex];
+    const canContinue =
+      continueRun &&
+      currentRun.active &&
+      currentRun.completedLevelTimes[levelIndex] == null &&
+      levelIndex >= currentRun.startedIndex;
+
+    if (!canContinue) {
+      currentRun = createEmptyRun(levelIndex);
+    }
+
+    currentRun.startedIndex = canContinue ? currentRun.startedIndex : levelIndex;
+    currentRun.active = true;
+
+    selectedLevelIndex = levelIndex;
+    currentLevelIndex = levelIndex;
+
+    prepareLevel(levelIndex);
+
+    gameState = GAME_STATES.PLAYING;
+    updateUIForState();
+    updateLevelButtonStates();
+    updateTimerDisplays();
+    closePanels();
+  }
+
+  function restartCurrentLevel() {
+    if (typeof currentLevelIndex !== "number") {
+      return;
+    }
+    startLevel(currentLevelIndex, { continueRun: true });
+  }
+
+  function prepareLevel(levelIndex) {
+    const level = levels[levelIndex];
+    currentLevel = level;
+
     dog = {
-      x: 80,
-      y: 360,
+      x: level.spawn.x,
+      y: level.spawn.y,
       width: 48,
       height: 46,
       vx: 0,
@@ -100,26 +357,12 @@
       earWiggle: 0,
     };
 
-    platforms = [
-      { x: 0, y: 470, width: canvas.width, height: 70, color: "#ffcf4a", accent: "#ffe9a3", label: "Scène Samba" },
-      { x: 110, y: 360, width: 170, height: 26, color: "#ff5ea3", accent: "#ffd2ec", label: "Char Tambours" },
-      { x: 330, y: 305, width: 150, height: 26, color: "#2ddf7c", accent: "#b8ffde", label: "Stand Limonade" },
-      { x: 530, y: 245, width: 190, height: 28, color: "#6a00f4", accent: "#d9c7ff", label: "Char Confettis" },
-      { x: 770, y: 340, width: 140, height: 26, color: "#ff7f50", accent: "#ffd1c2", label: "Float Bonbons" },
-      { x: 660, y: 430, width: 120, height: 22, color: "#00c2ff", accent: "#c6f3ff", label: "Chariot Glaces" },
-      { x: 420, y: 410, width: 120, height: 22, color: "#ffd447", accent: "#fff2a6", label: "Tambours" },
-    ];
+    platforms = level.createPlatforms().map((platform) => ({ ...platform }));
 
     collectibles.length = 0;
-    collectibles.push(
-      createTicket(180, 320, 0.1),
-      createTicket(375, 265, 0.5),
-      createTicket(600, 205, 0.9),
-      createTicket(810, 300, 1.4),
-      createTicket(700, 390, 1.9),
-      createTicket(480, 370, 2.2),
-      createTicket(260, 350, 2.8)
-    );
+    for (const ticketData of level.tickets) {
+      collectibles.push(createTicket(ticketData.x, ticketData.y, ticketData.phase));
+    }
 
     score = 0;
     celebration = false;
@@ -135,7 +378,11 @@
 
     ticketCountEl.textContent = "0";
     ticketTotalEl.textContent = String(collectibles.length);
-    statusEl.textContent = "Collecte tous les tickets pour déclencher la fête.";
+    statusEl.textContent = level.intro;
+    currentLevelNameEl.textContent = level.name;
+    levelTimer = 0;
+
+    updateTimerDisplays();
   }
 
   function createTicket(x, y, phase = 0) {
@@ -152,72 +399,94 @@
     };
   }
 
-  function update(delta) {
+  function update(delta, seconds) {
     time += delta;
     ferrisRotation = (ferrisRotation + 0.0045 * delta) % (Math.PI * 2);
 
-    if (jumpBuffer > 0) {
-      jumpBuffer = Math.max(0, jumpBuffer - delta);
+    if (!dog) {
+      updateConfetti(delta);
+      if (celebration) {
+        updateCelebration(delta);
+      }
+      return;
     }
 
-    const wasOnGround = dog.onGround;
-    if (wasOnGround) {
-      coyoteTimer = 6;
-    } else {
-      coyoteTimer = Math.max(0, coyoteTimer - delta);
-    }
+    if (gameState === GAME_STATES.PLAYING) {
+      if (jumpBuffer > 0) {
+        jumpBuffer = Math.max(0, jumpBuffer - delta);
+      }
 
-    if (jumpBuffer > 0 && coyoteTimer > 0) {
-      dog.vy = -dog.jumpStrength;
+      const wasOnGround = dog.onGround;
+      if (wasOnGround) {
+        coyoteTimer = 6;
+      } else {
+        coyoteTimer = Math.max(0, coyoteTimer - delta);
+      }
+
+      if (jumpBuffer > 0 && coyoteTimer > 0) {
+        dog.vy = -dog.jumpStrength;
+        dog.onGround = false;
+        coyoteTimer = 0;
+        jumpBuffer = 0;
+      }
+
+      const moveAcceleration = dog.acceleration * delta * (wasOnGround ? 1 : 0.55);
+      const friction = wasOnGround ? 0.78 : 0.93;
+
+      if (keys.left) {
+        dog.vx = Math.max(dog.vx - moveAcceleration, -dog.maxSpeed);
+        dog.facing = -1;
+      }
+
+      if (keys.right) {
+        dog.vx = Math.min(dog.vx + moveAcceleration, dog.maxSpeed);
+        dog.facing = 1;
+      }
+
+      if (!keys.left && !keys.right) {
+        dog.vx *= friction;
+        if (Math.abs(dog.vx) < 0.05) {
+          dog.vx = 0;
+        }
+      }
+
+      dog.vy = Math.min(dog.vy + gravity * delta, terminalVelocity);
+
+      dog.x += dog.vx * delta;
+      resolveCollisions(dog, "x");
+
+      dog.y += dog.vy * delta;
       dog.onGround = false;
-      coyoteTimer = 0;
+      resolveCollisions(dog, "y");
+
+      applyWorldBounds(dog);
+
+      const speedRatio = Math.min(Math.abs(dog.vx) / dog.maxSpeed, 1);
+      dog.runCycle += speedRatio * delta * 0.28;
+      if (dog.runCycle > Math.PI * 2) {
+        dog.runCycle -= Math.PI * 2;
+      }
+
+      dog.bob = dog.onGround
+        ? Math.abs(Math.sin(dog.runCycle * 2)) * speedRatio * 6
+        : Math.max(0, dog.bob - 0.8 * delta);
+      dog.tailSwing = Math.sin(time * 0.5 + dog.runCycle * 1.6) * (0.6 + speedRatio * 0.9);
+      dog.earWiggle = Math.sin(time * 0.7 + dog.runCycle) * (0.2 + speedRatio * 0.25);
+
+      updateCollectibles(delta);
+
+      levelTimer += seconds;
+      updateTimerDisplays();
+    } else if (gameState === GAME_STATES.CELEBRATING) {
+      keys.left = false;
+      keys.right = false;
       jumpBuffer = 0;
     }
 
-    const moveAcceleration = dog.acceleration * delta * (wasOnGround ? 1 : 0.55);
-    const friction = wasOnGround ? 0.78 : 0.93;
-
-    if (keys.left) {
-      dog.vx = Math.max(dog.vx - moveAcceleration, -dog.maxSpeed);
-      dog.facing = -1;
-    }
-
-    if (keys.right) {
-      dog.vx = Math.min(dog.vx + moveAcceleration, dog.maxSpeed);
-      dog.facing = 1;
-    }
-
-    if (!keys.left && !keys.right) {
-      dog.vx *= friction;
-      if (Math.abs(dog.vx) < 0.05) {
-        dog.vx = 0;
-      }
-    }
-
-    dog.vy = Math.min(dog.vy + gravity * delta, terminalVelocity);
-
-    dog.x += dog.vx * delta;
-    resolveCollisions(dog, "x");
-
-    dog.y += dog.vy * delta;
-    dog.onGround = false;
-    resolveCollisions(dog, "y");
-
-    applyWorldBounds(dog);
-
-    const speedRatio = Math.min(Math.abs(dog.vx) / dog.maxSpeed, 1);
-    dog.runCycle += speedRatio * delta * 0.28;
-    if (dog.runCycle > Math.PI * 2) {
-      dog.runCycle -= Math.PI * 2;
-    }
-
-    dog.bob = dog.onGround ? Math.abs(Math.sin(dog.runCycle * 2)) * speedRatio * 6 : Math.max(0, dog.bob - 0.8 * delta);
-    dog.tailSwing = Math.sin(time * 0.5 + dog.runCycle * 1.6) * (0.6 + speedRatio * 0.9);
-    dog.earWiggle = Math.sin(time * 0.7 + dog.runCycle) * (0.2 + speedRatio * 0.25);
-
-    updateCollectibles(delta);
     updateConfetti(delta);
-    updateCelebration(delta);
+    if (celebration) {
+      updateCelebration(delta);
+    }
   }
 
   function updateCollectibles(delta) {
@@ -251,17 +520,67 @@
         spawnConfettiBurst(ticket.x, ticket.currentY, 26);
 
         if (remaining === 0) {
-          startCelebration();
+          completeLevel();
         }
       }
     }
   }
 
-  function startCelebration() {
+  function completeLevel() {
+    if (celebration) {
+      return;
+    }
+
+    const levelTime = levelTimer;
+    const message = `Bravo ! ${currentLevel.name} terminé en ${formatTime(levelTime)} — feu d'artifice !`;
+
+    startCelebration(message);
+    gameState = GAME_STATES.CELEBRATING;
+
+    currentRun.completedLevelTimes[currentLevelIndex] = levelTime;
+    currentRun.totalTime += levelTime;
+    lastRunResults = {
+      times: [...currentRun.completedLevelTimes],
+      total: currentRun.totalTime,
+      startedIndex: currentRun.startedIndex,
+      timestamp: Date.now(),
+    };
+
+    const best = progress.bestLevelTimes[currentLevel.id];
+    if (best == null || levelTime < best) {
+      progress.bestLevelTimes[currentLevel.id] = levelTime;
+    }
+
+    const newlyUnlocked = Math.min(levels.length, currentLevelIndex + 2);
+    if (newlyUnlocked > progress.unlockedLevels) {
+      progress.unlockedLevels = newlyUnlocked;
+    }
+
+    saveProgress();
+    updateLevelButtonStates();
+    updateLastRunSummary();
+    updateTimerDisplays();
+
+    const finishedAllLevels =
+      currentRun.startedIndex === 0 &&
+      currentRun.completedLevelTimes.slice(0, levels.length).every((time) => time != null);
+
+    if (finishedAllLevels) {
+      currentRun.active = false;
+      handleRunFinished();
+    }
+
+    const nextLevelIndex = Math.min(progress.unlockedLevels - 1, currentLevelIndex + 1);
+    pendingMenuTimeout = window.setTimeout(() => {
+      enterMenu({ focusLevel: nextLevelIndex });
+    }, 2600);
+  }
+
+  function startCelebration(message) {
     celebration = true;
     celebrationTimer = 0;
     nextCelebrationBurst = 0;
-    statusEl.textContent = "Bravo ! Samba a récolté tous les tickets : place au feu d'artifice !";
+    statusEl.textContent = message || "Bravo ! Samba a récolté tous les tickets : place au feu d'artifice !";
     spawnConfettiBurst(canvas.width / 2, canvas.height / 4, 70);
   }
 
@@ -360,14 +679,33 @@
 
   function draw() {
     drawBackground();
-    drawCrowd();
-    drawPlatforms();
-    drawCollectibles();
-    drawDog();
+
+    if (gameState !== GAME_STATES.MENU && dog) {
+      drawPlatforms();
+      drawCollectibles();
+      drawDog();
+    }
+
     drawConfetti();
   }
 
   function drawBackground() {
+    const theme = currentLevel?.theme ?? "carnaval";
+
+    switch (theme) {
+      case "pirate":
+        drawPirateBackground();
+        break;
+      case "jouets":
+        drawToyBackground();
+        break;
+      default:
+        drawCarnivalBackground();
+        break;
+    }
+  }
+
+  function drawCarnivalBackground() {
     const skyGradient = ctx.createLinearGradient(0, 0, 0, canvas.height);
     skyGradient.addColorStop(0, "#07072b");
     skyGradient.addColorStop(0.45, "#102e73");
@@ -380,6 +718,210 @@
     drawTent(560, 360, 220, 110);
     drawBalloonCluster(860, 180);
     drawSpotlights();
+    drawCrowd();
+  }
+
+  function drawPirateBackground() {
+    const sky = ctx.createLinearGradient(0, 0, 0, canvas.height);
+    sky.addColorStop(0, "#010b19");
+    sky.addColorStop(0.5, "#04223a");
+    sky.addColorStop(1, "#0f4c75");
+    ctx.fillStyle = sky;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    ctx.save();
+    ctx.fillStyle = "rgba(255, 255, 210, 0.85)";
+    ctx.beginPath();
+    ctx.arc(140, 110, 48, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = "rgba(15, 76, 117, 0.35)";
+    ctx.beginPath();
+    ctx.arc(160, 108, 40, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.globalAlpha = 0.7;
+    ctx.fillStyle = "rgba(255, 255, 255, 0.9)";
+    for (let i = 0; i < 60; i += 1) {
+      const x = (i * 173) % canvas.width;
+      const y = 40 + ((i * 97) % 200);
+      const pulse = (Math.sin(time * 0.4 + i) + 1.4) * 0.3;
+      ctx.globalAlpha = 0.4 + pulse * 0.4;
+      ctx.beginPath();
+      ctx.arc(x, y, 1.5 + pulse, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    ctx.restore();
+
+    const ocean = ctx.createLinearGradient(0, canvas.height * 0.58, 0, canvas.height);
+    ocean.addColorStop(0, "#0b3d59");
+    ocean.addColorStop(1, "#021c2c");
+    ctx.fillStyle = ocean;
+    ctx.fillRect(0, canvas.height * 0.58, canvas.width, canvas.height * 0.42);
+
+    ctx.save();
+    ctx.strokeStyle = "rgba(255, 255, 255, 0.25)";
+    ctx.lineWidth = 2;
+    for (let i = 0; i < 5; i += 1) {
+      const waveY = canvas.height * 0.6 + i * 22;
+      ctx.beginPath();
+      for (let x = 0; x <= canvas.width; x += 12) {
+        const y = waveY + Math.sin((x / canvas.width) * Math.PI * 2 + time * 0.18 + i) * 6;
+        ctx.lineTo(x, y);
+      }
+      ctx.stroke();
+    }
+    ctx.restore();
+
+    ctx.save();
+    ctx.translate(canvas.width * 0.5, canvas.height * 0.6);
+
+    ctx.fillStyle = "#8c5a2b";
+    ctx.beginPath();
+    ctx.moveTo(-220, 0);
+    ctx.lineTo(190, 0);
+    ctx.lineTo(130, 90);
+    ctx.lineTo(-170, 90);
+    ctx.closePath();
+    ctx.fill();
+
+    ctx.fillStyle = "#c7894f";
+    ctx.fillRect(-150, -20, 300, 20);
+
+    ctx.fillStyle = "#f2e9d0";
+    ctx.fillRect(-12, -210, 12, 210);
+    ctx.fillRect(90, -170, 10, 170);
+
+    const sailSway = Math.sin(time * 0.35) * 16;
+
+    ctx.save();
+    ctx.translate(-12, -200);
+    ctx.beginPath();
+    ctx.moveTo(0, 0);
+    ctx.quadraticCurveTo(150 + sailSway, 50, 0, 200);
+    ctx.lineTo(0, 0);
+    ctx.fillStyle = "rgba(242, 233, 208, 0.95)";
+    ctx.fill();
+    ctx.restore();
+
+    ctx.save();
+    ctx.translate(88, -150);
+    ctx.beginPath();
+    ctx.moveTo(0, 0);
+    ctx.quadraticCurveTo(130 + sailSway * 0.5, 40, 0, 150);
+    ctx.lineTo(0, 0);
+    ctx.fillStyle = "rgba(230, 229, 240, 0.92)";
+    ctx.fill();
+    ctx.restore();
+
+    ctx.save();
+    ctx.translate(-6, -210);
+    const flagWave = Math.sin(time * 0.8) * 14;
+    ctx.fillStyle = "#102a43";
+    ctx.beginPath();
+    ctx.moveTo(0, 0);
+    ctx.lineTo(0, -60);
+    ctx.lineTo(90 + flagWave, -44);
+    ctx.lineTo(0, -20);
+    ctx.closePath();
+    ctx.fill();
+    ctx.fillStyle = "#ffe066";
+    ctx.beginPath();
+    ctx.arc(46 + flagWave * 0.3, -42, 10, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.restore();
+
+    ctx.fillStyle = "rgba(255, 255, 255, 0.2)";
+    for (let i = 0; i < 4; i += 1) {
+      ctx.beginPath();
+      ctx.arc(-120 + i * 80, 25, 12, Math.PI, 0);
+      ctx.fill();
+    }
+
+    ctx.restore();
+  }
+
+  function drawToyBackground() {
+    const wall = ctx.createLinearGradient(0, 0, 0, canvas.height);
+    wall.addColorStop(0, "#fff7ff");
+    wall.addColorStop(0.5, "#ffe3f1");
+    wall.addColorStop(1, "#ffd7a8");
+    ctx.fillStyle = wall;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    ctx.save();
+    const stripeWidth = 60;
+    for (let i = -2; i < canvas.width / stripeWidth + 2; i += 1) {
+      ctx.fillStyle = i % 2 === 0 ? "rgba(255, 182, 193, 0.25)" : "rgba(102, 208, 255, 0.2)";
+      ctx.fillRect(i * stripeWidth, 0, stripeWidth, canvas.height * 0.55);
+    }
+    ctx.restore();
+
+    ctx.save();
+    const lightY = 90;
+    for (let i = 0; i < 5; i += 1) {
+      const x = 120 + i * 180;
+      const pulse = Math.sin(time * 0.6 + i) * 0.35 + 0.9;
+      ctx.fillStyle = `rgba(255, 224, 102, ${0.18 + pulse * 0.22})`;
+      ctx.beginPath();
+      ctx.arc(x, lightY, 80 * pulse, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.fillStyle = "#ffe066";
+      ctx.beginPath();
+      ctx.arc(x, lightY, 18, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    ctx.restore();
+
+    ctx.save();
+    ctx.fillStyle = "rgba(244, 162, 97, 0.88)";
+    ctx.beginPath();
+    ctx.moveTo(0, canvas.height * 0.55);
+    ctx.lineTo(canvas.width, canvas.height * 0.55);
+    ctx.lineTo(canvas.width, canvas.height);
+    ctx.lineTo(0, canvas.height);
+    ctx.closePath();
+    ctx.fill();
+    ctx.fillStyle = "rgba(255, 214, 160, 0.7)";
+    for (let i = 0; i <= canvas.width; i += 90) {
+      ctx.fillRect(i, canvas.height * 0.55 + (i % 180 === 0 ? 8 : 0), 60, canvas.height * 0.45);
+    }
+    ctx.restore();
+
+    ctx.save();
+    ctx.translate(0, canvas.height * 0.55);
+    const shelfColors = ["#ff85a1", "#66d0ff", "#2ddf7c", "#ffe066", "#d38eff", "#ffb347"];
+    for (let row = 0; row < 3; row += 1) {
+      const shelfY = -row * 90 - 40;
+      ctx.fillStyle = "rgba(255, 255, 255, 0.9)";
+      ctx.fillRect(80, shelfY, canvas.width - 160, 18);
+      for (let i = 0; i < 6; i += 1) {
+        const color = shelfColors[(row + i) % shelfColors.length];
+        const boxX = 120 + i * 120 + Math.sin(time * 0.45 + row + i) * 4;
+        ctx.fillStyle = color;
+        ctx.fillRect(boxX, shelfY - 70, 70, 60);
+        ctx.fillStyle = "rgba(255, 255, 255, 0.35)";
+        ctx.fillRect(boxX, shelfY - 70, 70, 12);
+      }
+    }
+    ctx.restore();
+
+    ctx.save();
+    const balloonColors = ["#ff5ea3", "#66d0ff", "#2ddf7c", "#ffe066"];
+    for (let i = 0; i < 4; i += 1) {
+      const baseX = 140 + i * 220;
+      const offsetX = Math.sin(time * 0.5 + i) * 10;
+      const offsetY = Math.cos(time * 0.6 + i) * 10;
+      ctx.fillStyle = balloonColors[i % balloonColors.length];
+      ctx.beginPath();
+      ctx.ellipse(baseX + offsetX, 220 + offsetY, 24, 32, 0, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.strokeStyle = "rgba(20, 40, 80, 0.25)";
+      ctx.beginPath();
+      ctx.moveTo(baseX + offsetX, 252 + offsetY);
+      ctx.lineTo(baseX + offsetX - 6, 300 + offsetY * 0.5);
+      ctx.stroke();
+    }
+    ctx.restore();
   }
 
   function drawCrowd() {
@@ -635,9 +1177,10 @@
     ctx.scale(dog.facing, 1);
     ctx.translate(-dog.width / 2, -dog.height);
 
-    const bodyColor = "#c67c48";
-    const spotColor = "#d89a64";
-    const outline = "#6f3a1b";
+    const skin = currentSkin ?? skins[0];
+    const bodyColor = skin.body;
+    const spotColor = skin.spots;
+    const outline = skin.outline;
 
     // Tail
     ctx.save();
@@ -814,19 +1357,359 @@
     return color;
   }
 
+  function handlePlayClick() {
+    if (selectedLevelIndex >= progress.unlockedLevels) {
+      return;
+    }
+    const continueRun = shouldContinueRun(selectedLevelIndex);
+    startLevel(selectedLevelIndex, { continueRun });
+  }
+
+  function togglePanel(button, panel) {
+    const isExpanded = button.getAttribute("aria-expanded") === "true";
+    if (isExpanded) {
+      button.setAttribute("aria-expanded", "false");
+      panel.hidden = true;
+    } else {
+      closePanels(button);
+      button.setAttribute("aria-expanded", "true");
+      panel.hidden = false;
+    }
+  }
+
+  function closePanels(exceptButton) {
+    const panels = [
+      { button: characterButton, panel: characterPanel },
+      { button: levelButton, panel: levelPanel },
+    ];
+    for (const { button, panel } of panels) {
+      if (button === exceptButton) {
+        continue;
+      }
+      button.setAttribute("aria-expanded", "false");
+      panel.hidden = true;
+    }
+  }
+
+  function updateUIForState() {
+    const inMenu = gameState === GAME_STATES.MENU;
+    mainMenu.hidden = !inMenu;
+    hudEl.hidden = inMenu;
+    gameAreaEl.hidden = inMenu;
+    restartButton.hidden = gameState !== GAME_STATES.PLAYING;
+    restartButton.disabled = gameState !== GAME_STATES.PLAYING;
+  }
+
+  function clearPendingMenuTimeout() {
+    if (pendingMenuTimeout !== null) {
+      clearTimeout(pendingMenuTimeout);
+      pendingMenuTimeout = null;
+    }
+  }
+
+  function createEmptyRun(startIndex = 0) {
+    return {
+      startedIndex: startIndex,
+      completedLevelTimes: new Array(levels.length).fill(null),
+      totalTime: 0,
+      active: false,
+    };
+  }
+
+  function updateTimerDisplays() {
+    levelTimerEl.textContent = formatTime(levelTimer);
+    const total = currentRun.totalTime + (gameState === GAME_STATES.PLAYING ? levelTimer : 0);
+    totalTimerEl.textContent = formatTime(total);
+  }
+
+  function formatTime(totalSeconds) {
+    if (!Number.isFinite(totalSeconds) || totalSeconds < 0) {
+      return "0:00.000";
+    }
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = Math.floor(totalSeconds % 60);
+    const milliseconds = Math.round((totalSeconds - Math.floor(totalSeconds)) * 1000);
+    return `${minutes}:${String(seconds).padStart(2, "0")}.${String(milliseconds).padStart(3, "0")}`;
+  }
+
+  function buildSkinOptions() {
+    skinButtons.clear();
+    characterOptionsEl.textContent = "";
+    skins.forEach((skin) => {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "skin-option";
+      button.setAttribute("role", "listitem");
+
+      const preview = document.createElement("span");
+      preview.className = "skin-option__preview";
+      preview.style.background = skin.body;
+      preview.style.boxShadow = `inset 0 0 0.5rem ${skin.spots}`;
+
+      const label = document.createElement("span");
+      label.textContent = skin.name;
+
+      button.append(preview, label);
+      button.addEventListener("click", () => {
+        selectSkin(skin);
+      });
+
+      characterOptionsEl.append(button);
+      skinButtons.set(skin.id, button);
+    });
+
+    updateSkinSelection();
+  }
+
+  function selectSkin(skin) {
+    currentSkin = skin;
+    progress.selectedSkinId = skin.id;
+    saveProgress();
+    updateSkinSelection();
+  }
+
+  function updateSkinSelection() {
+    skinButtons.forEach((button, id) => {
+      if (id === currentSkin.id) {
+        button.classList.add("is-selected");
+      } else {
+        button.classList.remove("is-selected");
+      }
+    });
+    characterButton.textContent = `Sélection de personnage — ${currentSkin.name}`;
+  }
+
+  function buildLevelOptions() {
+    levelButtonRefs.length = 0;
+    levelListEl.textContent = "";
+
+    levels.forEach((level, index) => {
+      const item = document.createElement("li");
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "level-option";
+      button.dataset.levelIndex = String(index);
+
+      const label = document.createElement("span");
+      label.textContent = `${index + 1}. ${level.name}`;
+
+      const meta = document.createElement("span");
+      meta.className = "level-option__meta";
+
+      button.append(label, meta);
+      button.addEventListener("click", () => {
+        if (index >= progress.unlockedLevels) {
+          return;
+        }
+        setSelectedLevel(index);
+      });
+
+      item.append(button);
+      levelListEl.append(item);
+      levelButtonRefs.push({ button, meta, index });
+    });
+
+    updateLevelButtonStates();
+  }
+
+  function updateLevelButtonStates() {
+    for (const { button, meta, index } of levelButtonRefs) {
+      const level = levels[index];
+      const isUnlocked = index < progress.unlockedLevels;
+      const best = progress.bestLevelTimes[level.id];
+
+      button.disabled = !isUnlocked;
+      button.classList.toggle("is-selected", isUnlocked && index === selectedLevelIndex);
+      if (!isUnlocked) {
+        meta.textContent = "🔒 Termine le niveau précédent";
+      } else if (best != null) {
+        meta.textContent = `Meilleur : ${formatTime(best)}`;
+      } else {
+        meta.textContent = "Aucun temps enregistré";
+      }
+    }
+
+    updatePlayButtonText();
+  }
+
+  function setSelectedLevel(index) {
+    if (index < 0 || index >= levels.length) {
+      return;
+    }
+    if (index >= progress.unlockedLevels) {
+      return;
+    }
+    selectedLevelIndex = index;
+    updateLevelButtonStates();
+  }
+
+  function updatePlayButtonText() {
+    const level = levels[selectedLevelIndex];
+    const continuing = shouldContinueRun(selectedLevelIndex);
+    playButton.textContent = `${continuing ? "Continuer" : "Jouer"} — ${level.name}`;
+    playButton.disabled = selectedLevelIndex >= progress.unlockedLevels;
+  }
+
+  function shouldContinueRun(levelIndex) {
+    if (!currentRun.active) {
+      return false;
+    }
+    const nextIndex = currentRun.completedLevelTimes.findIndex(
+      (time, idx) => idx >= currentRun.startedIndex && time == null
+    );
+    if (nextIndex === -1) {
+      return false;
+    }
+    return nextIndex === levelIndex;
+  }
+
+  function enterMenu({ focusLevel, skipFocus } = {}) {
+    clearPendingMenuTimeout();
+
+    const maxSelectable = Math.max(0, progress.unlockedLevels - 1);
+    if (typeof focusLevel === "number") {
+      selectedLevelIndex = Math.min(maxSelectable, Math.max(0, focusLevel));
+    } else {
+      selectedLevelIndex = Math.min(selectedLevelIndex, maxSelectable);
+    }
+
+    gameState = GAME_STATES.MENU;
+    updateLevelButtonStates();
+    updateUIForState();
+    closePanels();
+    updateTimerDisplays();
+    updateLeaderboardDisplay();
+    updateLastRunSummary();
+
+    if (!skipFocus) {
+      playButton.focus();
+    }
+  }
+
+  function handleRunFinished() {
+    if (!lastRunResults) {
+      return;
+    }
+
+    let enteredName = "";
+    if (typeof window !== "undefined" && typeof window.prompt === "function") {
+      enteredName = window.prompt(
+        "Bravo ! Tu as terminé tous les niveaux. Entre ton nom pour le classement :",
+        currentSkin?.name ?? "Samba"
+      );
+    }
+
+    const sanitized = (enteredName ?? "").trim().slice(0, 24);
+    const entryName = sanitized || currentSkin?.name || "Samba";
+
+    progress.leaderboard.push({
+      name: entryName,
+      totalTime: currentRun.totalTime,
+      timestamp: Date.now(),
+    });
+
+    progress.leaderboard.sort((a, b) => a.totalTime - b.totalTime);
+    progress.leaderboard = progress.leaderboard.slice(0, 5);
+    saveProgress();
+    updateLeaderboardDisplay();
+  }
+
+  function updateLeaderboardDisplay() {
+    if (!Array.isArray(progress.leaderboard) || progress.leaderboard.length === 0) {
+      leaderboardEmptyEl.hidden = false;
+      leaderboardListEl.hidden = true;
+      leaderboardListEl.textContent = "";
+      return;
+    }
+
+    leaderboardEmptyEl.hidden = true;
+    leaderboardListEl.hidden = false;
+    leaderboardListEl.textContent = "";
+
+    progress.leaderboard.forEach((entry) => {
+      const li = document.createElement("li");
+      li.textContent = `${entry.name} — ${formatTime(entry.totalTime)}`;
+      leaderboardListEl.append(li);
+    });
+  }
+
+  function updateLastRunSummary() {
+    if (!lastRunResults || !lastRunResults.times.some((time) => time != null)) {
+      lastRunSummaryEl.hidden = true;
+      lastRunListEl.textContent = "";
+      return;
+    }
+
+    lastRunSummaryEl.hidden = false;
+    lastRunListEl.textContent = "";
+
+    lastRunResults.times.forEach((time, index) => {
+      if (time == null) {
+        return;
+      }
+      const item = document.createElement("li");
+      item.textContent = `${index + 1}. ${levels[index].name} — ${formatTime(time)}`;
+      lastRunListEl.append(item);
+    });
+
+    const totalItem = document.createElement("li");
+    totalItem.textContent = `Total : ${formatTime(lastRunResults.total)}`;
+    totalItem.style.fontWeight = "700";
+    lastRunListEl.append(totalItem);
+  }
+
+  function saveProgress() {
+    if (typeof window === "undefined" || !window.localStorage) {
+      return;
+    }
+    try {
+      const payload = JSON.stringify(progress);
+      window.localStorage.setItem(STORAGE_KEY, payload);
+    } catch (error) {
+      // Ignore storage errors (private mode, quota, etc.)
+    }
+  }
+
+  function loadProgress() {
+    if (typeof window === "undefined" || !window.localStorage) {
+      return null;
+    }
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      if (!stored) {
+        return null;
+      }
+      return JSON.parse(stored);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function initialize() {
+    currentLevelNameEl.textContent = levels[currentLevelIndex].name;
+    buildSkinOptions();
+    buildLevelOptions();
+    updateTimerDisplays();
+    updateLeaderboardDisplay();
+    updateLastRunSummary();
+    enterMenu({ focusLevel: selectedLevelIndex, skipFocus: true });
+  }
+
   function gameLoop(timestamp) {
     if (!gameLoop.lastTime) {
       gameLoop.lastTime = timestamp;
     }
-    const delta = Math.min((timestamp - gameLoop.lastTime) / 16.6667, 2.5);
+    const elapsed = timestamp - gameLoop.lastTime;
+    const delta = Math.min(elapsed / 16.6667, 2.5);
+    const seconds = elapsed / 1000;
     gameLoop.lastTime = timestamp;
 
-    update(delta);
+    update(delta, seconds);
     draw();
 
     requestAnimationFrame(gameLoop);
   }
 
-  resetGame();
+  initialize();
   requestAnimationFrame(gameLoop);
 })();

--- a/index.html
+++ b/index.html
@@ -13,6 +13,55 @@
         Aide Samba, le chien acrobate, à collecter les tickets du carnaval pour
         lancer le feu d'artifice final !
       </p>
+
+      <section id="main-menu" class="menu" aria-labelledby="menu-title">
+        <h2 id="menu-title">Menu principal</h2>
+        <div class="menu__buttons">
+          <button id="play-button" type="button">Jouer</button>
+          <button
+            id="character-button"
+            type="button"
+            aria-expanded="false"
+            aria-controls="character-panel"
+          >
+            Sélection de personnage
+          </button>
+          <button
+            id="level-button"
+            type="button"
+            aria-expanded="false"
+            aria-controls="level-panel"
+          >
+            Sélection de niveau
+          </button>
+        </div>
+        <div id="character-panel" class="menu__panel" hidden>
+          <h3>Choisis le pelage de Samba</h3>
+          <div id="character-options" class="skin-options" role="list"></div>
+        </div>
+        <div id="level-panel" class="menu__panel" hidden>
+          <h3>Choisis un niveau</h3>
+          <ol id="level-list" class="level-options"></ol>
+        </div>
+        <section class="leaderboard" aria-labelledby="leaderboard-title">
+          <h3 id="leaderboard-title">Classement du carnaval</h3>
+          <p id="leaderboard-empty">
+            Aucun temps enregistré pour l'instant. Terminez les trois niveaux
+            d'affilée pour figurer ici !
+          </p>
+          <ol id="leaderboard-list" hidden></ol>
+        </section>
+        <section
+          id="last-run-summary"
+          class="menu__summary"
+          aria-labelledby="summary-title"
+          hidden
+        >
+          <h3 id="summary-title">Dernière performance</h3>
+          <ul id="last-run-list"></ul>
+        </section>
+      </section>
+
       <div class="hud" role="status" aria-live="polite">
         <p class="hud__score">
           <span aria-hidden="true">🎟️</span>
@@ -20,6 +69,19 @@
           <span id="ticket-count">0</span>
           /
           <span id="ticket-total">0</span>
+        </p>
+        <div class="hud__timers">
+          <p class="hud__timer">
+            <span class="hud__timer-label">Temps niveau :</span>
+            <span id="level-timer">0:00.000</span>
+          </p>
+          <p class="hud__timer">
+            <span class="hud__timer-label">Temps total :</span>
+            <span id="total-timer">0:00.000</span>
+          </p>
+        </div>
+        <p class="hud__level">
+          Niveau : <span id="current-level-name">Carnaval</span>
         </p>
         <p id="status">Collecte tous les tickets pour déclencher la fête.</p>
       </div>

--- a/style.css
+++ b/style.css
@@ -48,12 +48,205 @@ h1 {
   max-width: 40ch;
 }
 
-.hud {
+.menu {
+  margin: 0 auto 2rem;
+  padding: 1.5rem 1.75rem 2rem;
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 1.25rem;
+  border: 0.25rem solid rgba(106, 0, 244, 0.1);
+  box-shadow: inset 0 0 2rem rgba(102, 208, 255, 0.15),
+    0 1rem 2.5rem rgba(20, 40, 80, 0.15);
+}
+
+.menu h2 {
+  margin: 0 0 1.25rem;
+  color: var(--carnival-purple);
+}
+
+.menu__buttons {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.menu__buttons button {
+  font-size: 1rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  border: none;
+  padding: 0.85rem 1.8rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--carnival-pink), var(--carnival-purple));
+  color: white;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+  box-shadow: 0 0.75rem 1.8rem rgba(106, 0, 244, 0.35);
+}
+
+.menu__buttons button:hover,
+.menu__buttons button:focus-visible {
+  transform: translateY(-0.2rem) scale(1.02);
+  box-shadow: 0 1.25rem 2.5rem rgba(106, 0, 244, 0.4);
+}
+
+.menu__buttons button:focus-visible {
+  outline: 0.25rem solid var(--carnival-yellow);
+  outline-offset: 0.25rem;
+}
+
+.menu__panel {
+  margin: 0 auto 1.5rem;
+  padding: 1.25rem;
+  border-radius: 1rem;
+  border: 0.2rem dashed rgba(106, 0, 244, 0.2);
+  background: rgba(102, 208, 255, 0.18);
+  max-width: 720px;
+  text-align: left;
+}
+
+.skin-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+  margin-top: 1rem;
+}
+
+.skin-option {
+  border: none;
+  padding: 0.75rem 1.25rem;
+  border-radius: 0.75rem;
+  background: rgba(255, 255, 255, 0.8);
+  box-shadow: 0 0.5rem 1.2rem rgba(20, 40, 80, 0.15);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border 0.2s ease;
+}
+
+.skin-option:focus-visible {
+  outline: 0.25rem solid var(--carnival-yellow);
+  outline-offset: 0.2rem;
+}
+
+.skin-option__preview {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  border: 0.2rem solid rgba(20, 40, 80, 0.2);
+}
+
+.skin-option.is-selected {
+  transform: translateY(-0.2rem);
+  box-shadow: 0 1.25rem 2.5rem rgba(106, 0, 244, 0.35);
+  border: 0.2rem solid var(--carnival-yellow);
+}
+
+.level-options {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.level-option {
+  width: 100%;
+  text-align: left;
+  border: none;
+  padding: 1rem 1.25rem;
+  border-radius: 0.9rem;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 0.5rem 1.2rem rgba(20, 40, 80, 0.12);
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  flex-wrap: wrap;
   gap: 1rem;
+}
+
+.level-option:hover,
+.level-option:focus-visible {
+  transform: translateY(-0.2rem);
+  box-shadow: 0 1.25rem 2.5rem rgba(20, 40, 80, 0.25);
+}
+
+.level-option:focus-visible {
+  outline: 0.25rem solid var(--carnival-yellow);
+  outline-offset: 0.2rem;
+}
+
+.level-option[disabled] {
+  cursor: not-allowed;
+  opacity: 0.6;
+  filter: grayscale(0.1);
+  transform: none;
+  box-shadow: none;
+}
+
+.level-option.is-selected {
+  border: 0.2rem solid var(--carnival-yellow);
+  box-shadow: 0 1.25rem 2.5rem rgba(255, 224, 102, 0.35);
+}
+
+.level-option__meta {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: rgba(20, 40, 80, 0.75);
+}
+
+.leaderboard {
+  margin: 0 auto 1.5rem;
+  padding: 1.25rem 1.5rem;
+  border-radius: 1rem;
+  background: rgba(255, 224, 102, 0.2);
+  border: 0.2rem dashed rgba(106, 0, 244, 0.2);
+  max-width: 720px;
+  text-align: left;
+}
+
+.leaderboard ol {
+  list-style: decimal inside;
+  margin: 0.75rem 0 0;
+  padding: 0;
+}
+
+.leaderboard li {
+  padding: 0.35rem 0;
+  font-weight: 600;
+}
+
+.menu__summary {
+  margin: 0 auto;
+  padding: 1.25rem;
+  border-radius: 1rem;
+  border: 0.2rem dashed rgba(106, 0, 244, 0.2);
+  background: rgba(255, 255, 255, 0.75);
+  max-width: 720px;
+  text-align: left;
+}
+
+.menu__summary ul {
+  list-style: none;
+  margin: 0.75rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.hud {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1.5rem;
   background: linear-gradient(135deg, var(--carnival-yellow), #fff4d6);
   padding: 0.75rem 1.5rem;
   border-radius: 999px;
@@ -68,6 +261,28 @@ h1 {
   display: flex;
   align-items: center;
   gap: 0.35rem;
+}
+
+.hud__timers {
+  display: flex;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.hud__timer {
+  margin: 0;
+  font-weight: 600;
+}
+
+.hud__timer-label {
+  display: inline-block;
+  margin-right: 0.25rem;
+}
+
+.hud__level {
+  margin: 0;
+  font-weight: 700;
 }
 
 #status {


### PR DESCRIPTION
## Summary
- add a main menu that exposes play, character selection, level selection, and leaderboard panels
- introduce three themed levels with unlockable progression and character palette swaps
- track level and run completion times, surface them in the HUD, and persist best totals to a leaderboard

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cd37ccfd248333ab5f2871406212c5